### PR TITLE
Added loading cache, that does async fetching of the Google Calendar events.

### DIFF
--- a/src/main/kotlin/org/steffeleffe/CalendarResource.kt
+++ b/src/main/kotlin/org/steffeleffe/CalendarResource.kt
@@ -17,7 +17,7 @@ class CalendarResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     fun getAllCalendars(): List<CalendarEvent> {
-        return calendarService.getAllCalendars(5)
+        return calendarService.getAllCalendars()
     }
 
 }

--- a/src/main/kotlin/org/steffeleffe/CssResource.kt
+++ b/src/main/kotlin/org/steffeleffe/CssResource.kt
@@ -31,7 +31,7 @@ open class CssResource {
     @Timed(name = "timed", description = "A measure of how long it takes to fetch css page.", unit = MetricUnits.MILLISECONDS)
     @Produces(MediaType.TEXT_PLAIN)
     open fun hello(): String {
-        val allCalendars = calendarService.getAllCalendars(5)
+        val allCalendars = calendarService.getAllCalendars()
         val usedTimes = getAllTimesUsedInEvents(allCalendars)
 
         val cssBuilder = CSSBuilder().apply {

--- a/src/main/kotlin/org/steffeleffe/HtmlResource.kt
+++ b/src/main/kotlin/org/steffeleffe/HtmlResource.kt
@@ -26,7 +26,7 @@ open class HtmlResource {
     @Timed(name = "timed", description = "A measure of how long it takes to fetch index page.", unit = MetricUnits.MILLISECONDS)
     @Produces(MediaType.TEXT_HTML)
     open fun hello(): String {
-        val allCalendars = calendarService.getAllCalendars(5)
+        val allCalendars = calendarService.getAllCalendars()
         val createHTML = createHTML(true, true)
         createHTML.head {
             styleLink("/style.css")

--- a/src/main/kotlin/org/steffeleffe/calendarservice/CalendarService.kt
+++ b/src/main/kotlin/org/steffeleffe/calendarservice/CalendarService.kt
@@ -1,24 +1,21 @@
 package org.steffeleffe.calendarservice
 
-import org.steffeleffe.calendarimport.GoogleCalendarImporter
 import javax.enterprise.context.ApplicationScoped
-import javax.enterprise.inject.Default
-import javax.inject.Inject
 
 @ApplicationScoped
-open class CalendarService {
+open class CalendarService() {
 
-    private val googleCalendarImporter = GoogleCalendarImporter()
+    private val cache = CalenderEventCache().cache
 
-    fun getAllCalendars(numberOfDays: Int): List<CalendarEvent> {
+    fun getAllCalendars(): List<CalendarEvent> {
 
         val joinedList = mutableListOf<CalendarEvent>()
 
-        joinedList.addAll(googleCalendarImporter.importCalender("primary", numberOfDays))
-        joinedList.addAll(googleCalendarImporter.importCalender("3eq4uqnkhcgipgkdrrhs7ec6e4@group.calendar.google.com", numberOfDays))
-        joinedList.addAll(googleCalendarImporter.importCalender("rikke.vangsted@gmail.com", numberOfDays))
-        joinedList.addAll(googleCalendarImporter.importCalender("66aglhcacpcpupnhh9fian0a1g@group.calendar.google.com", numberOfDays))
-        joinedList.addAll(googleCalendarImporter.importCalender("hdn3t11kjru1fs823pee8g9bso@group.calendar.google.com", numberOfDays))
+        joinedList.addAll(cache.get("primary"))
+        joinedList.addAll(cache.get("3eq4uqnkhcgipgkdrrhs7ec6e4@group.calendar.google.com"))
+        joinedList.addAll(cache.get("rikke.vangsted@gmail.com"))
+        joinedList.addAll(cache.get("66aglhcacpcpupnhh9fian0a1g@group.calendar.google.com"))
+        joinedList.addAll(cache.get("hdn3t11kjru1fs823pee8g9bso@group.calendar.google.com"))
 
         return joinedList
     }

--- a/src/main/kotlin/org/steffeleffe/calendarservice/CalenderEventCache.kt
+++ b/src/main/kotlin/org/steffeleffe/calendarservice/CalenderEventCache.kt
@@ -1,0 +1,39 @@
+package org.steffeleffe.calendarservice
+
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.CacheLoader
+import com.google.common.cache.LoadingCache
+import com.google.common.util.concurrent.ListenableFutureTask
+import org.steffeleffe.calendarimport.GoogleCalendarImporter
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+
+class CalenderEventCache {
+
+    private val numberOfDays = 5
+
+    private val googleCalendarImporter = GoogleCalendarImporter()
+
+    inner class CalendarEventCacheLoader : CacheLoader<String, List<CalendarEvent>>() {
+        override fun load(key: String): List<CalendarEvent> { // no checked exception
+            return getEvents(key)
+        }
+
+        override fun reload(key: String, oldValue: List<CalendarEvent>): ListenableFutureTask<List<CalendarEvent>> {
+            val task: ListenableFutureTask<List<CalendarEvent>> = ListenableFutureTask.create { getEvents(key) }
+            Executors.newSingleThreadExecutor().execute(task)
+            return task
+        }
+
+        private fun getEvents(key: String) : List<CalendarEvent> = googleCalendarImporter.importCalender(key, numberOfDays)
+
+    }
+
+    val cache: LoadingCache<String, List<CalendarEvent>> = CacheBuilder.newBuilder()
+            .maximumSize(1000)
+            .refreshAfterWrite(1, TimeUnit.MINUTES)
+            .build(CalendarEventCacheLoader())
+
+
+}


### PR DESCRIPTION
Cached events are refreshed (instead of expired) so that old events are still available in case of network error.
Fixes #1 